### PR TITLE
Silence alarming warnings when book has null cdetype.

### DIFF
--- a/librariansync/kindle_contents.py
+++ b/librariansync/kindle_contents.py
@@ -3,6 +3,8 @@ import re
 import locale
 import time
 
+from kindle_logging import log, LIBRARIAN_SYNC
+
 KINDLE_EBOOKS_ROOT = "/mnt/us/documents/"
 
 SUPPORTED_EXTENSIONS = [".azw",
@@ -104,7 +106,7 @@ class Collection(object):
                 else:
                     # Proper or fake ASIN set, build the hash
                     hashes_list.append('#{}^{}'.format(e.cdekey, e.cdetype))
-           else:
+            else:
                 log(LIBRARIAN_SYNC, "legacy hash building",
                     "Book %s has no cdeKey?! Skipping it."
                     "(sideloaded book?)" % e.location,

--- a/librariansync/kindle_contents.py
+++ b/librariansync/kindle_contents.py
@@ -96,12 +96,19 @@ class Collection(object):
     def build_legacy_hashes_list(self):
         hashes_list = []
         for e in self.original_ebooks:
-            if e.cdekey.startswith('*'):
-                # No ASIN set, we don't care about the cdeType, use it as-is
-                hashes_list.append(e.cdekey)
-            else:
-                # Proper or fake ASIN set, build the hash
-                hashes_list.append('#{}^{}'.format(e.cdekey, e.cdetype))
+            # Guard against NULL cdeKeys, which should never happen for books, but have been seen in the wild w/ manually sideloaded stuff...
+            if e.cdekey:
+                if e.cdekey.startswith('*'):
+                    # No ASIN set, we don't care about the cdeType, use it as-is
+                    hashes_list.append(e.cdekey)
+                else:
+                    # Proper or fake ASIN set, build the hash
+                    hashes_list.append('#{}^{}'.format(e.cdekey, e.cdetype))
+           else:
+                log(LIBRARIAN_SYNC, "legacy hash building",
+                    "Book %s has no cdeKey?! Skipping it."
+                    "(sideloaded book?)" % e.location,
+                    "W", display=False)
         return hashes_list
 
     def to_calibre_plugin_json(self):


### PR DESCRIPTION
Unlikely to happen in practice... but it did happen to me, so... fix it anyway?

Although it seems no harm is actually done (at least, my before and after collections.json were identical), this may have been coincidence.